### PR TITLE
feat: Add NLP server and retriver func # 31

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+data-ai/nlp-server/retriever/news_20231026.db filter=lfs diff=lfs merge=lfs -text

--- a/data-ai/nlp-server/main.py
+++ b/data-ai/nlp-server/main.py
@@ -1,0 +1,93 @@
+from typing import Annotated
+from fastapi import FastAPI, Header, HTTPException
+
+import json
+
+import bareunpy as brn
+
+with open('security.json', 'r') as f:
+    security = json.load(f)
+    
+app = FastAPI()
+tagger = brn.Tagger(apikey=security['bareun'],
+                    host=security['bareun-host'],
+                    port=security['bareun-port']
+                    )
+
+def check_auth(serviceKey:str | None = None, Authorization: Annotated[str | None, Header()] = None):
+    '''
+        check service key in database.
+    '''
+    if serviceKey == None and Authorization == None:
+        raise HTTPException(status_code=404, detail="required Authorization")
+    
+    if serviceKey == None:
+        serviceKey = Authorization
+        
+    if serviceKey in security['service-key']:
+        raise HTTPException(status_code=404, detail='invalid serviceKey')
+
+
+@app.get("/chat")
+async def chat(query:str, serviceKey:str | None = None, Authorization: Annotated[str | None, Header()] = None):
+    '''
+        make answer from query.
+        :param query: question string
+        :param serviceKey(str, option): authorization key
+        :param Authorization(str, option): authorization key
+        
+        if serviceKey and Authorization is None, raise HTTPException
+        
+        -> return json {
+            "query": query,
+            "contexts": contexts, # List[Document]
+            "answers": answers
+            }
+    '''    
+    check_auth(serviceKey, Authorization)
+    
+    # get response from bareu api
+    res = tagger.tag([query])
+    # remove unnecessary pos
+    pos = [i[0] for i in res.pos()
+            if i[1] in ['SL', 'SH', 'SN',  
+                        #SL: 외국어 # SH: 한자 # SN: 숫자
+                        'NNP', 'NNG', 'NNB', 'NR',
+                        # NNP: 고유명사 # NNG: 일반명사 # NNB: 의존명사 # NR: 수사
+                        'VV', 'VA', 'VX', 'VCP', 'VCN',
+                        # VV: 동사 # VA: 형용사 # VX: 보조용언 # VCP: 긍정지정사 # VCN: 부정지정사
+                        'XR'
+                        # XR: 어근
+                        ]
+           ]
+
+    contexts = "retrieved context"
+    answers = "generated answer"
+    
+    return {
+        "query": query,
+        "contexts": contexts,
+        "answers": answers,
+        "pos": pos,
+        }
+
+@app.get("/tag")
+async def tag(query:str, serviceKey:str | None = None, Authorization: Annotated[str | None, Header()] = None) -> dict:
+    """_summary_
+
+    Args:
+        query (str): _description_
+        serviceKey (str | None, optional): _description_. Defaults to None.
+        Authorization (Annotated[str  |  None, Header, optional): _description_. Defaults to None.
+
+    Returns:
+        retrun pos, nouns, verbs using baren api
+    """
+    
+    check_auth(serviceKey, Authorization)
+    
+    res = tagger.tags([query])
+    nowns = res.nouns()
+    verbs = res.verbs()
+    
+    return {"query": query, "serviceKey": serviceKey, 'tagged': res.pos(),'nouns': nowns, 'verbs': verbs}

--- a/data-ai/nlp-server/retriever/create_index.py
+++ b/data-ai/nlp-server/retriever/create_index.py
@@ -1,0 +1,16 @@
+from haystack.document_stores import ElasticsearchDocumentStore, SQLDocumentStore
+
+if __name__ == '__main__':
+    # conver DocumentStore from SQL to Elasticsearch
+    documents = SQLDocumentStore(url="sqlite:///news_20231026.db").get_all_documents()
+    """
+    host: str Elasticsearch host url e.g localhost, 127.0.0.1
+    username: str Elasticsearch id
+    password: str Elasticsearch auth password
+    index: str Elasticsearch index name
+    
+    we store crawled news data in Elasticsearch.
+    index name is `news`
+    """
+    documentStore = ElasticsearchDocumentStore(host="localhost", username="", password="", index="news")
+    documentStore.write_documents(documents,duplicate_documents='overwrite')

--- a/data-ai/nlp-server/retriever/make_document.py
+++ b/data-ai/nlp-server/retriever/make_document.py
@@ -1,0 +1,48 @@
+from haystack.document_stores import SQLDocumentStore
+from haystack.schema import Document
+import os
+import jsonlines
+from tqdm.auto import tqdm
+
+if __name__ == '__main__':
+    """_summary_
+    make document from crawled news data
+    
+    In JSONL format, each line is a JSON object below.
+    ```JSON
+        {"content": "Main body of the news article",
+         "title": "Title of the article",
+         "created": "Creation time in datetime",
+         "url": "Link to the article"
+        }
+    ```
+    For example, the file name is `news_정치_20231001.jsonl`, the category is `정치`, and the date is `20231001`
+    documet format is below.
+    Documet = {
+        "content": "Main body of the news article",
+        "meta": {
+            "title": "Title of the article",
+            "created": "Creation time in datetime",
+            "url": "Link to the article",
+            "category": "정치"
+        }
+    }
+    store sqlite database file name is `news_20231026.db`
+    """
+    document_files = os.listdir()
+    doocument_store = SQLDocumentStore(url="sqlite:///news_20231026.db", duplicate_documents='skip')
+    documents = []
+    for file in tqdm(document_files, unit="file"):
+        if file.endswith(".jsonl"):
+            with jsonlines.open(file) as reader:
+                category = file.split("_")[1]
+                for obj in tqdm(reader, leave=False, unit="doc"):
+                    document = Document(
+                        content=obj['content'],
+                        meta={
+                                "title":obj["title"], "created":obj["created"],
+                                "url":obj["url"], "category":category
+                            }
+                    )
+                    documents.append(document)
+    doocument_store.write_documents(documents)

--- a/data-ai/nlp-server/retriever/news_20231026.db
+++ b/data-ai/nlp-server/retriever/news_20231026.db
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8b30556db4ceb7343dc543a072a32e50e58431d81c854ad38df630d6dfbb9f6c
+size 1872396288

--- a/data-ai/nlp-server/retriever/retriever.py
+++ b/data-ai/nlp-server/retriever/retriever.py
@@ -1,0 +1,15 @@
+from haystack.nodes import BM25Retriever
+from haystack.document_stores import ElasticsearchDocumentStore
+from typing import List
+
+# load document store
+document_store = ElasticsearchDocumentStore(host="localhost", username="", password="", index="news")
+# create retriever node
+retriever = BM25Retriever(document_store=document_store)
+
+def retrieve(query: str, top_k: int = 5):
+    # retrieve top 5 documents
+    return retriever.retrieve(query=query, top_k=top_k)
+
+def retrieve_batch(queries: List[str], top_k: int = 5):
+    return retriever.retrieve_batch(queries=queries, top_k=top_k)

--- a/data-ai/nlp-server/start.sh
+++ b/data-ai/nlp-server/start.sh
@@ -1,0 +1,2 @@
+#! /bin/bash
+uvicorn main:app --host 0.0.0.0 --port 8000 --reload


### PR DESCRIPTION
This commit adds the necessary files to implement an NLP server and retriever functionality. The new files include a .gitattributes file, main.py, __init__.py, create_index.py, make_document.py, news_20231026.db, retriever.py, and start.sh. These files will allow users to search and retrieve relevant documents based on their queries.

On branch feature/31/retriever
Closes #31